### PR TITLE
[Ensure Behavior] Update issue template for the latest Github suggestion

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,8 @@
-# Submitting questions
-
-If you have a question like "how do I do X?", this is not the right place for asking it. Please ask on the [Crystal Forum](https://forum.crystal-lang.org), on our combined [Gitter](https://gitter.im/crystal-lang/crystal)/[IRC](http://webchat.freenode.net/?channels=#crystal-lang) or on [StackOverflow](http://stackoverflow.com/questions/tagged/crystal-lang).
+---
+name: Bug report
+about: Create a report to help us improve
+labels: kind:bug
+---
 
 # Submitting bugs
 
@@ -12,3 +14,7 @@ Make sure to review these points before submitting issues - thank you!
 - Reduce code, if possible, to the minimum size that reproduces the bug.
 - If all of the above is impossible due to a large project, create a branch that reproduces the bug and point us to it.
 - Include Crystal compiler version (`crystal -v`) and OS. If possible, try to see if the bug still reproduces on master.
+
+## Submitting questions
+
+If you have a question like "how do I do X?", this is not the right place for asking it. Please ask on the one of [contact_links](https://github.com/crystal-lang/crystal/blob/master/.github/ISSUE_TEMPLATE/config.yml).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Forum
+    url: https://forum.crystal-lang.org
+    about: Please ask and answer questions here.
+  - name: Gitter
+    url: https://gitter.im/crystal-lang/crystal
+    about: Please ask and answer questions here.
+  - name: IRC
+    url: http://webchat.freenode.net/?channels=#crystal-lang
+    about: Please ask and answer questions here.
+  - name: Stack Overflow
+    url: http://stackoverflow.com/questions/tagged/crystal-lang
+    about: Please ask and answer questions here.


### PR DESCRIPTION
Current style looks came from https://docs.github.com/en/github/building-a-strong-community/manually-creating-a-single-issue-template-for-your-repository
Github said it is the `legacy` way.

So the latest style suggested at here.

https://docs.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates
https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser